### PR TITLE
Fix syntax errors in older browsers, e.g., MSIE 11.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,8 @@
         "browsers": [
           "last 2 chrome versions",
           "last 2 firefox versions",
-          "safari >= 11"
+          "safari >= 11",
+          "ie 11"
         ]
       },
       "modules": false


### PR DESCRIPTION
In order to present users a message that they need to update their browser (MSIE 11 seems stiil to be used in institutes), at least packages should not cause syntax errors. This change slightly changes the translation by babel in order to make the code also work in Internet Explorer 11. There is no guarantee that all features will work in that browser, though.